### PR TITLE
Various degrees of applydrunk to simulate alcohol abv

### DIFF
--- a/Content/Afflictions/MiscAfflictions.xml
+++ b/Content/Afflictions/MiscAfflictions.xml
@@ -521,6 +521,60 @@
       </Effect>
       <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="384,640,128,128" color="170,194,147,255" origin="0,0" />
     </Affliction>
+
+    <Affliction identifier="applydrunkmedium"
+      description="Converts into normal drunk affliction over time to simulate alcohol taking time to take effect"
+      type="debuff"
+      causeofdeathdescription="Alcohol poisoning"
+      selfcauseofdeathdescription="You have died of alcohol poisoning."
+      limbspecific="false"
+      indicatorlimb="Torso"
+      activationthreshold="0"
+      showiconthreshold="1000"
+      showicontoothersthreshold="1000"
+      hideiconafterdelay="true"
+      showinhealthscannerthreshold="1000"
+      treatmentthreshold="1000"
+      maxstrength="100"
+      affectmachines="false"
+      MedicalSkillGain="0.0"
+      healableinmedicalclinic="false">
+      <Effect minstrength="0" maxstrength="100" strengthchange="0.0">
+        <StatusEffect target="Character" delay="6" duration="6" stackable="false" disabledeltatime="false" checkconditionalalways="true" multiplyafflictionsbymaxvitality="true">
+          <Conditional applydrunkmedium="gt 0" />
+          <Affliction identifier="drunk" strength="1.015" />
+          <ReduceAffliction identifier="applydrunkmedium" strength="1.015" />
+        </StatusEffect>
+      </Effect>
+      <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="384,640,128,128" color="170,194,147,255" origin="0,0" />
+    </Affliction>
+
+    <Affliction identifier="applydrunkfast"
+      description="Converts into normal drunk affliction over time to simulate alcohol taking time to take effect"
+      type="debuff"
+      causeofdeathdescription="Alcohol poisoning"
+      selfcauseofdeathdescription="You have died of alcohol poisoning."
+      limbspecific="false"
+      indicatorlimb="Torso"
+      activationthreshold="0"
+      showiconthreshold="1000"
+      showicontoothersthreshold="1000"
+      hideiconafterdelay="true"
+      showinhealthscannerthreshold="1000"
+      treatmentthreshold="1000"
+      maxstrength="100"
+      affectmachines="false"
+      MedicalSkillGain="0.0"
+      healableinmedicalclinic="false">
+      <Effect minstrength="0" maxstrength="100" strengthchange="0.0">
+        <StatusEffect target="Character" delay="3" duration="3" stackable="false" disabledeltatime="false" checkconditionalalways="true" multiplyafflictionsbymaxvitality="true">
+          <Conditional applydrunkfast="gt 0" />
+          <Affliction identifier="drunk" strength="1.015" />
+          <ReduceAffliction identifier="applydrunkfast" strength="1.015" />
+        </StatusEffect>
+      </Effect>
+      <icon texture="Content/UI/MainIconsAtlas.png" sourcerect="384,640,128,128" color="170,194,147,255" origin="0,0" />
+    </Affliction>
     
     <Affliction name="Disoriented"
       identifier="he-drunkinvertcontrols"

--- a/Content/Items/Food/Drinks.xml
+++ b/Content/Items/Food/Drinks.xml
@@ -63,7 +63,7 @@
           <Conditional HasTag="opened" />
           <Affliction identifier="he-internalburn" amount="8" />
           <Affliction identifier="psychosisresistance" amount="80" />
-          <Affliction identifier="applydrunk" amount="6.0" />
+          <Affliction identifier="applydrunkfast" amount="6.0" />
           <ReduceAffliction identifier="psychosis" amount="10.0" />
           <ReduceAffliction identifier="hallucinating" amount="10.0" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Drinks/Drinking.ogg" loop="true" range="200" volume="5.0" />
@@ -275,7 +275,7 @@
           <ReduceAffliction identifier="hallucinating" amount="1" />
           <ReduceAffliction identifier="he-halucinova" amount="1" />
           <ReduceAffliction identifier="embarrassment" strength="1" />
-          <Affliction identifier="applydrunk" amount="3" />
+          <Affliction identifier="applydrunkfast" amount="3" />
           <ReduceAffliction type="thirst" amount="1.5" />
           <Affliction identifier="fillbladder" amount="2.0" />
           <Affliction identifier="drank_rum" amount="1" />
@@ -451,7 +451,7 @@
           <ReduceAffliction identifier="hallucinating" amount="1" />
           <ReduceAffliction identifier="he-halucinova" amount="1" />
           <ReduceAffliction identifier="embarrassment" strength="1" />
-          <Affliction identifier="applydrunk" amount="3" />
+          <Affliction identifier="applydrunkfast" amount="3" />
           <Affliction identifier="radiationsickness" amount="0.5" />
           <ReduceAffliction type="thirst" amount="1.5" />
           <Affliction identifier="fillbladder" amount="2.0" />
@@ -545,7 +545,7 @@
           <Conditional condition="lt 11" />
           <Conditional HasTag="opened" />
           <Affliction identifier="psychosisresistance" amount="6" />
-          <Affliction identifier="applydrunk" amount="2.5" />
+          <Affliction identifier="applydrunkmedium" amount="2.5" />
           <ReduceAffliction identifier="hallucinating" amount="2.0" />
           <ReduceAffliction identifier="psychosis" amount="2.0" />
           <ReduceAffliction identifier="nausea" amount="2" />
@@ -649,7 +649,7 @@
           <Conditional InWater="false" />
           <Conditional condition="lt 11" />
           <Conditional HasTag="opened" />
-          <Affliction identifier="drunk" amount="3.0" />
+          <Affliction identifier="applydrunkmedium" amount="3.0" />
           <Affliction identifier="he-halucinova" amount="9.0" />
           <ReduceAffliction identifier="embarrassment" strength="10" />
           <Affliction identifier="oxygenlow" amount="1.0" />


### PR DESCRIPTION
Drinks with higher alcohol concentration will take effect faster, so this is reflected in the form of a medium and fast speed variant of applydrunk. The default applydrunk takes effect in 10 seconds, medium takes effect in 6, and fast takes effect in 3. Whiskey and Halucinova are medium speed, both rums and plain ethanol are fast speed.

Also changes Halucinova to inflict applydrunk instead of the previous direct application of drunk.