### PR TITLE
Sweet foods and drinks always reduce stress, more foods considered sweet

### DIFF
--- a/Content/Afflictions/TraitsAfflictions.xml
+++ b/Content/Afflictions/TraitsAfflictions.xml
@@ -197,6 +197,9 @@
     <Affliction name="" identifier="drank_cola" description="" type="trait" limbspecific="false" indicatorlimb="Head" maxstrength="1" affectmachines="false" showiconthreshold="1000" showicontoothersthreshold="1000" showinhealthscannerthreshold="1000" healableinmedicalclinic="false">
       <Effect minstrength="0" maxstrength="1" strengthchange="-1" resistancefor="drank_cola" minresistance="0" maxresistance="0" multiplybymaxvitality="true">
         <StatusEffect target="Character" interval="1" disabledeltatime="true">
+          <ReduceAffliction identifier="mood" amount="0.5" />
+        </StatusEffect> 
+        <StatusEffect target="Character" interval="1" disabledeltatime="true">
           <Conditional trait_likes_cola="gt 0" />
           <ReduceAffliction identifier="mood" amount="1.0" />
         </StatusEffect> 

--- a/Content/Afflictions/TraitsAfflictions.xml
+++ b/Content/Afflictions/TraitsAfflictions.xml
@@ -132,6 +132,7 @@
     <Affliction name="" identifier="ate_sweet" description="" type="trait" limbspecific="false" indicatorlimb="Head" maxstrength="1" affectmachines="false" showiconthreshold="1000" showicontoothersthreshold="1000" showinhealthscannerthreshold="1000" healableinmedicalclinic="false">
       <Effect minstrength="0" maxstrength="1" strengthchange="-1" resistancefor="ate_sweet" minresistance="0" maxresistance="0" multiplybymaxvitality="true">
         <StatusEffect target="Character" interval="1" disabledeltatime="true">
+          <Conditional trait_dislikes_sweets="eq 0" />
           <ReduceAffliction identifier="mood" amount="0.5" />
         </StatusEffect> 
         <StatusEffect target="Character" interval="1" disabledeltatime="true">
@@ -197,6 +198,7 @@
     <Affliction name="" identifier="drank_cola" description="" type="trait" limbspecific="false" indicatorlimb="Head" maxstrength="1" affectmachines="false" showiconthreshold="1000" showicontoothersthreshold="1000" showinhealthscannerthreshold="1000" healableinmedicalclinic="false">
       <Effect minstrength="0" maxstrength="1" strengthchange="-1" resistancefor="drank_cola" minresistance="0" maxresistance="0" multiplybymaxvitality="true">
         <StatusEffect target="Character" interval="1" disabledeltatime="true">
+          <Conditional trait_dislikes_cola="eq 0" />
           <ReduceAffliction identifier="mood" amount="0.5" />
         </StatusEffect> 
         <StatusEffect target="Character" interval="1" disabledeltatime="true">

--- a/Content/Afflictions/TraitsAfflictions.xml
+++ b/Content/Afflictions/TraitsAfflictions.xml
@@ -132,6 +132,9 @@
     <Affliction name="" identifier="ate_sweet" description="" type="trait" limbspecific="false" indicatorlimb="Head" maxstrength="1" affectmachines="false" showiconthreshold="1000" showicontoothersthreshold="1000" showinhealthscannerthreshold="1000" healableinmedicalclinic="false">
       <Effect minstrength="0" maxstrength="1" strengthchange="-1" resistancefor="ate_sweet" minresistance="0" maxresistance="0" multiplybymaxvitality="true">
         <StatusEffect target="Character" interval="1" disabledeltatime="true">
+          <ReduceAffliction identifier="mood" amount="0.5" />
+        </StatusEffect> 
+        <StatusEffect target="Character" interval="1" disabledeltatime="true">
           <Conditional trait_likes_sweets="gt 0" />
           <ReduceAffliction identifier="mood" amount="1.0" />
         </StatusEffect> 

--- a/Content/Afflictions/TraitsAfflictions.xml
+++ b/Content/Afflictions/TraitsAfflictions.xml
@@ -132,7 +132,7 @@
     <Affliction name="" identifier="ate_sweet" description="" type="trait" limbspecific="false" indicatorlimb="Head" maxstrength="1" affectmachines="false" showiconthreshold="1000" showicontoothersthreshold="1000" showinhealthscannerthreshold="1000" healableinmedicalclinic="false">
       <Effect minstrength="0" maxstrength="1" strengthchange="-1" resistancefor="ate_sweet" minresistance="0" maxresistance="0" multiplybymaxvitality="true">
         <StatusEffect target="Character" interval="1" disabledeltatime="true">
-          <Conditional trait_dislikes_sweets="eq 0" />
+          <Conditional trait_dislikes_sweets="neq 1" />
           <ReduceAffliction identifier="mood" amount="0.5" />
         </StatusEffect> 
         <StatusEffect target="Character" interval="1" disabledeltatime="true">
@@ -198,7 +198,7 @@
     <Affliction name="" identifier="drank_cola" description="" type="trait" limbspecific="false" indicatorlimb="Head" maxstrength="1" affectmachines="false" showiconthreshold="1000" showicontoothersthreshold="1000" showinhealthscannerthreshold="1000" healableinmedicalclinic="false">
       <Effect minstrength="0" maxstrength="1" strengthchange="-1" resistancefor="drank_cola" minresistance="0" maxresistance="0" multiplybymaxvitality="true">
         <StatusEffect target="Character" interval="1" disabledeltatime="true">
-          <Conditional trait_dislikes_cola="eq 0" />
+          <Conditional trait_dislikes_cola="neq 1" />
           <ReduceAffliction identifier="mood" amount="0.5" />
         </StatusEffect> 
         <StatusEffect target="Character" interval="1" disabledeltatime="true">

--- a/Content/Items/Food/DairyProducts.xml
+++ b/Content/Items/Food/DairyProducts.xml
@@ -112,6 +112,7 @@
           <Affliction identifier="he-sugarrich" amount="4" />
           <ReduceAffliction type="hunger" amount="0.1" />
           <Affliction identifier="spill" amount="1000" probability="0.0005" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>
         
@@ -126,6 +127,7 @@
           <Affliction identifier="he-sugarrich" amount="4" />
           <ReduceAffliction type="hunger" amount="0.1" />
           <Affliction identifier="spill" amount="1000" probability="0.0005" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>
         
@@ -247,6 +249,7 @@
           <Affliction identifier="he-sugarrich" amount="8" />
           <ReduceAffliction type="hunger" amount="0.1" />
           <Affliction identifier="spill" amount="1000" probability="0.0005" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>
         
@@ -261,6 +264,7 @@
           <Affliction identifier="he-sugarrich" amount="8" />
           <ReduceAffliction type="hunger" amount="0.1" />
           <Affliction identifier="spill" amount="1000" probability="0.0005" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>
         <StatusEffect type="OnBroken" target="This">
@@ -381,6 +385,7 @@
           <Affliction identifier="he-sugarrich" amount="8" />
           <ReduceAffliction type="hunger" amount="0.1" />
           <Affliction identifier="spill" amount="1000" probability="0.0005" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>
         
@@ -395,6 +400,7 @@
           <Affliction identifier="he-sugarrich" amount="8" />
           <ReduceAffliction type="hunger" amount="0.1" />
           <Affliction identifier="spill" amount="1000" probability="0.0005" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>
         <StatusEffect type="OnBroken" target="This">
@@ -515,6 +521,7 @@
           <Affliction identifier="he-sugarrich" amount="8" />
           <ReduceAffliction type="hunger" amount="0.1" />
           <Affliction identifier="spill" amount="1000" probability="0.0005" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>
         
@@ -529,6 +536,7 @@
           <Affliction identifier="he-sugarrich" amount="8" />
           <ReduceAffliction type="hunger" amount="0.1" />
           <Affliction identifier="spill" amount="1000" probability="0.0005" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>
         <StatusEffect type="OnBroken" target="This">

--- a/Content/Items/Food/DairyProducts.xml
+++ b/Content/Items/Food/DairyProducts.xml
@@ -778,20 +778,24 @@
         </StatusEffect>
         <!--Additional effects-->
         <!--Decrease hunger depending on ice cream balls contained, only if needs are enabled-->
+        <!--Counts towards eating sweets, for decreasing stress-->
         <StatusEffect type="OnUse" target="Character" comparison="And">
           <Conditional InWater="false" />
           <RequiredItem tag="icecreamball" type="contained" targetslot="0" />
           <ReduceAffliction type="hunger" amount="0.4" />
+          <Affliction identifier="ate_sweet" amount="1" />
         </StatusEffect>
         <StatusEffect type="OnUse" target="Character" comparison="And">
           <Conditional InWater="false" />
           <RequiredItem tag="icecreamball" type="contained" targetslot="1" />
           <ReduceAffliction type="hunger" amount="0.4" />
+          <Affliction identifier="ate_sweet" amount="1" />
         </StatusEffect>
         <StatusEffect type="OnUse" target="Character" comparison="And">
           <Conditional InWater="false" />
           <RequiredItem tag="icecreamball" type="contained" targetslot="2" />
           <ReduceAffliction type="hunger" amount="0.4" />
+          <Affliction identifier="ate_sweet" amount="1" />
         </StatusEffect>
         <!--Increase damage resistance affliction if milky ice cream ball is contained-->
         <StatusEffect type="OnUse" target="Character" comparison="And">
@@ -835,6 +839,7 @@
           <Conditional HasStatusTag="neq secondslot" />
           <Conditional HasStatusTag="neq thirdslot" />
           <Affliction identifier="he-stuffed" amount="0.05" />
+          <Affliction identifier="ate_sweet" amount="1" />
         </StatusEffect>
         <!--Play soft eating sound if containing ice cream-->
         <StatusEffect type="OnUse" target="This">

--- a/Content/Items/Food/Drinks.xml
+++ b/Content/Items/Food/Drinks.xml
@@ -1673,6 +1673,7 @@
           <ReduceAffliction identifier="he-halucinova" amount="0.1" />
           <Affliction identifier="he-sugarrich" amount="15.0" />
           <Affliction identifier="fillbladder" amount="3.0" />
+          <Affliction identifier="ate_sweet" amount="1.0" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Drinks/Drinking.ogg" loop="true" range="200" volume="5.0" />
         </StatusEffect>
         

--- a/Content/Items/Food/Food_Misc.xml
+++ b/Content/Items/Food/Food_Misc.xml
@@ -26,6 +26,7 @@
           <Affliction identifier="he-proteinrich" amount="8.0" />
           <Affliction identifier="he-stuffed" amount="0.75" />
           <ReduceAffliction type="hunger" amount="0.75" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>
         
@@ -45,6 +46,7 @@
           <Affliction identifier="he-proteinrich" amount="8.0" />
           <Affliction identifier="he-stuffed" amount="0.75" />
           <ReduceAffliction type="hunger" amount="0.75" />
+          <Affliction identifier="ate_sweet" amount="1" />
           <ParticleEmitter particle="whitechunks" particlespersecond="2" scalemin="0.15" scalemax="0.2" distancemin="0" distancemax="5" anglemin="200" anglemax="340" velocitymin="10" velocitymax="15" copyentityangle="true" colormultiplier="120,80,30,255" />
           <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
         </StatusEffect>

--- a/Content/Items/Gardening/PlantProduce.xml
+++ b/Content/Items/Gardening/PlantProduce.xml
@@ -43,6 +43,7 @@
         <ReduceAffliction type="thirst" amount="0.8" />
         <Affliction identifier="fillbladder" amount="0.8" />
         <Affliction identifier="he-vitaminrich" amount="5.0" />
+        <Affliction identifier="ate_sweet" amount="1.0" />
         <ParticleEmitter particle="whitechunks" particlespersecond="5" scalemin="0.2" scalemax="0.35" distancemin="5" distancemax="15" anglemin="180" anglemax="180" velocitymin="0" velocitymax="10" copyentityangle="true" colormultiplier="200,100,50,255" />
         <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
       </StatusEffect>
@@ -224,6 +225,7 @@
         <ReduceAffliction type="nausea" amount="0.5" />
         <ReduceAffliction type="opiatewithdrawal" amount="0.5" />
         <Affliction identifier="spill" amount="1000" probability="0.0005" />
+        <Affliction identifier="ate_sweet" amount="1.0" />
         <ParticleEmitter particle="whitechunks" particlespersecond="3" scalemin="0.2" scalemax="0.35" distancemin="10" distancemax="15" anglemin="95" anglemax="95" velocitymin="0" velocitymax="10" copyentityangle="true" colormultiplier="230,220,180,255" />
         <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
       </StatusEffect>
@@ -274,6 +276,7 @@
         <ReduceAffliction type="thirst" amount="0.8" />
         <Affliction identifier="fillbladder" amount="0.8" />
         <Affliction identifier="he-vitaminrich" amount="5.0" />
+        <Affliction identifier="ate_sweet" amount="1.0" />
         <ParticleEmitter particle="whitechunks" particlespersecond="5" scalemin="0.2" scalemax="0.35" distancemin="5" distancemax="15" anglemin="180" anglemax="180" velocitymin="0" velocitymax="10" copyentityangle="true" colormultiplier="70,125,190,255" />
         <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
       </StatusEffect>
@@ -353,6 +356,7 @@
       <StatusEffect type="OnUse" target="This" condition="-1" statuseffecttags="iseating" duration="0.1" stackable="false" />
       <StatusEffect type="OnUse" target="Character">
         <ReduceAffliction type="hunger" amount="1" />
+        <Affliction identifier="ate_sweet" amount="1.0" />
         <ParticleEmitter particle="whitechunks" particlespersecond="5" scalemin="0.2" scalemax="0.35" distancemin="5" distancemax="15" anglemin="180" anglemax="180" velocitymin="0" velocitymax="10" copyentityangle="true" colormultiplier="90,70,40,255" />
         <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingCrunchy.ogg" loop="True" range="200" volume="5.0" />
       </StatusEffect>
@@ -806,6 +810,7 @@
         <ReduceAffliction type="psychosis" amount="1.5" />
         <ReduceAffliction type="hunger" amount="0.4" />
         <ReduceAffliction identifier="he-stomachache" amount="1.5" />
+        <Affliction identifier="ate_sweet" amount="1.0" />
         <ParticleEmitter particle="whitechunks" particlespersecond="5" scalemin="0.2" scalemax="0.35" distancemin="5" distancemax="15" anglemin="180" anglemax="180" velocitymin="0" velocitymax="10" copyentityangle="true" colormultiplier="120,105,70,255" />
         <Sound file="%ModDir:2954998725%/Content/Sounds/Items/Food/EatingSoft.ogg" loop="True" range="200" volume="5.0" />
       </StatusEffect>


### PR DESCRIPTION
Ate_sweet always reduces stress slightly, regardless of whether the character likes sweets, but not if the character dislikes sweets. Same for drank_cola; always reduces some stress unless disliked. Will stack with the likes sweets/cola effect.

Ice cream balls, ice cream waffle, and any balls in the waffles provide ate_sweet. Protein bars, pomegrenades, bananas, bubbleberries, popped popnut, pomacco, pomberry juice provide ate_sweet.